### PR TITLE
Add provision for setting geckodriver location

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -3,7 +3,9 @@ import time
 import sys
 from selenium.webdriver.common.by import By
 
-driver = webdriver.Firefox()
+service = webdriver.FirefoxService(executable_path="/home/asdf/geckodriver")
+
+driver = webdriver.Firefox(service=service)
 
 url="https://www.instagram.com/"
 

--- a/scraper.py
+++ b/scraper.py
@@ -3,7 +3,7 @@ import time
 import sys
 from selenium.webdriver.common.by import By
 
-service = webdriver.FirefoxService(executable_path="/home/asdf/geckodriver")
+service = webdriver.FirefoxService(executable_path="path_to_geckodriver")
 
 driver = webdriver.Firefox(service=service)
 


### PR DESCRIPTION
this adds a provision for setting the location of geckodriver, necessary under ubuntu 24.04 when firefox is installed as a snap to avoid the "The geckodriver version (0.35.0) detected in PATH at /snap/bin/geckodriver might not be compatible with the detected firefox version (136.0.2); currently, geckodriver 0.36.0 is recommended for firefox 136.*, so it is advised to delete the driver in PATH and retry" error.